### PR TITLE
Session을 통한 플레이어 이름 관련 인가 구현

### DIFF
--- a/Last-Stand-server/Server/Controller/DataController.cs
+++ b/Last-Stand-server/Server/Controller/DataController.cs
@@ -40,26 +40,19 @@ namespace Server.Controller
             [FromServices] IAccountService accountService)
         {
             if (!Request.Headers.TryGetValue("Session-Id", out var sessionId))
-                return Unauthorized(new {message = "Session Id Is Not Found"});
-            
+                return Unauthorized(new { message = "Session Id Is Not Found" });
+
             var accountId = await sessionService.GetAccountIdBySessionIdAsync(sessionId);
             if (accountId == null)
                 return Unauthorized(new { message = "Invalid or expired session." });
-            
-            Console.WriteLine($"AccountId from session: {accountId}");
 
             var playerData = await accountService.GetPlayerLoginDataByIdAsync(accountId.Value);
-            if (playerData == null)
-                return Unauthorized(new { message = "Player not found for this session." });
-            
-            Console.WriteLine($"PlayerId from account service: {playerData.PlayerId}");
-
-            if (req.PlayerId != playerData.PlayerId)
+            if (playerData == null || req.PlayerId != playerData.PlayerId)
                 return Unauthorized(new { message = "Session does not match player." });
 
             if (string.IsNullOrWhiteSpace(req.PlayerId) || string.IsNullOrWhiteSpace(req.PlayerName))
                 return BadRequest(new { message = "PlayerId and PlayerName are required." });
-                    
+
             if (await _dataService.IsNameTakenAsync(req.PlayerName))
                 return Conflict(new { message = "PlayerName is already taken." });
 
@@ -73,7 +66,7 @@ namespace Server.Controller
             var loginData = await _accountService.GetPlayerLoginDataByPlayerIdAsync(req.PlayerId);
             if (loginData == null)
                 return NotFound(new { message = "Player Not Found" });
-            
+
             var newData = new PlayerData
             {
                 Id = loginData.Id,
@@ -90,5 +83,6 @@ namespace Server.Controller
                 PlayerName = req.PlayerName
             });
         }
+
     }
 }

--- a/Last-Stand-server/Server/Program.cs
+++ b/Last-Stand-server/Server/Program.cs
@@ -26,7 +26,11 @@ builder.Services.AddSingleton<IConnectionMultiplexer>(sp =>
     return ConnectionMultiplexer.Connect(configuration);
 });
 
-builder.Services.AddControllers();
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.PropertyNameCaseInsensitive = true;
+    });
 
 builder.Services.AddCors(options =>
 {

--- a/Last-Stand-server/Server/Repository/AccountRepository.cs
+++ b/Last-Stand-server/Server/Repository/AccountRepository.cs
@@ -119,4 +119,18 @@ public class AccountRepository : IAccountRepository
 
         return await connection.QueryFirstOrDefaultAsync<PlayerLoginData>(query, new { PlayerId = playerId });
     }
+
+    public async Task<PlayerLoginData?> GetPlayerLoginDataByIdAsync(int id)
+    {
+        const string sql = @"
+        SELECT id, player_id, password, email, is_new_account
+        FROM player_account_data
+        WHERE id = @Id
+        LIMIT 1";
+        
+        await using var connection = new MySqlConnection(_connectionString);
+        await connection.OpenAsync();
+        
+        return await connection.QueryFirstOrDefaultAsync<PlayerLoginData>(sql, new { Id = id });    
+    }
 }

--- a/Last-Stand-server/Server/Repository/AccountRepository.cs
+++ b/Last-Stand-server/Server/Repository/AccountRepository.cs
@@ -123,10 +123,10 @@ public class AccountRepository : IAccountRepository
     public async Task<PlayerLoginData?> GetPlayerLoginDataByIdAsync(int id)
     {
         const string sql = @"
-        SELECT id, player_id, password, email, is_new_account
-        FROM player_account_data
-        WHERE id = @Id
-        LIMIT 1";
+            SELECT id, player_id AS PlayerId, password AS Password, email, is_new_account AS IsNewAccount
+            FROM player_account_data
+            WHERE id = @Id
+            LIMIT 1;";
         
         await using var connection = new MySqlConnection(_connectionString);
         await connection.OpenAsync();

--- a/Last-Stand-server/Server/Repository/Interface/IAccountRepository.cs
+++ b/Last-Stand-server/Server/Repository/Interface/IAccountRepository.cs
@@ -13,4 +13,5 @@ public interface IAccountRepository
     Task<PlayerLoginData?> FindByPlayerIdAndEmailAsync(string playerId, string email);
     Task UpdatePasswordAsync(string playerId, string newPassword);
     Task<PlayerLoginData> GetPlayerLoginDataByPlayerIdAsync(string playerId);
+    Task<PlayerLoginData?> GetPlayerLoginDataByIdAsync(int id);
 }

--- a/Last-Stand-server/Server/Repository/SessionRepository.cs
+++ b/Last-Stand-server/Server/Repository/SessionRepository.cs
@@ -31,11 +31,24 @@ public class SessionRepository : ISessionRepository
     public async Task<AccountSession?> GetValidSessionAsync(string sessionId)
     {
         const string sql = @"
-            SELECT * FROM account_session
+            SELECT 
+                session_id AS SessionId, 
+                account_id AS AccountId, 
+                created_at AS CreatedAt, 
+                expires_at AS ExpiresAt 
+            FROM account_session
             WHERE session_id = @SessionId AND expires_at > UTC_TIMESTAMP()";
         
         await using var connection  = CreateConnection();
-        return await connection.QueryFirstOrDefaultAsync<AccountSession>(sql, new { SessionId = sessionId });
+        
+        var session = await connection.QueryFirstOrDefaultAsync<AccountSession>(sql, new { SessionId = sessionId });
+        
+        if (session != null)
+            Console.WriteLine($"Session found: SessionId={session.SessionId}, AccountId={session.AccountId}");
+        else
+            Console.WriteLine("Session not found or expired.");
+        
+        return session;
     }
 
     public async Task<bool> HasValidSessionByAccountIdAsync(int accountId)

--- a/Last-Stand-server/Server/Service/AccountService.cs
+++ b/Last-Stand-server/Server/Service/AccountService.cs
@@ -37,6 +37,11 @@ public class AccountService : IAccountService
         return await _accountRepository.GetPlayerLoginDataByPlayerIdAsync(playerId);
     }
 
+    public async Task<PlayerLoginData?> GetPlayerLoginDataByIdAsync(int id)
+    {
+        return await _accountRepository.GetPlayerLoginDataByIdAsync(id);
+    }
+
     public async Task UpdateIsNewAccountAsync(string playerId, bool isNewAccount)
     {
         await _accountRepository.UpdateIsNewAccountAsync(playerId, isNewAccount);

--- a/Last-Stand-server/Server/Service/Interface/IAccountService.cs
+++ b/Last-Stand-server/Server/Service/Interface/IAccountService.cs
@@ -7,6 +7,7 @@ public interface IAccountService
     Task<string?> FindPlayerIdByEmailAsync(string email);
     Task<bool> ResetPasswordAsync(string playerId, string email, string newPassword);
     Task<PlayerLoginData?> GetPlayerLoginDataByPlayerIdAsync(string playerId);
+    Task<PlayerLoginData?> GetPlayerLoginDataByIdAsync(int id);
     Task UpdateIsNewAccountAsync(string playerId, bool isNewAccount);
     Task<bool?> CheckIsNewAccountByPlayerIdAsync(string playerId);
 }

--- a/Last-Stand-server/Server/Service/Interface/ISessionService.cs
+++ b/Last-Stand-server/Server/Service/Interface/ISessionService.cs
@@ -4,4 +4,5 @@ public interface ISessionService
 {
     Task<string> CreateSessionAsync(string playerId);
     Task<string?> GetPlayerIdBySessionIdAsync(string sessionId);
+    Task<int?> GetAccountIdBySessionIdAsync(string sessionId);
 }

--- a/Last-Stand-server/Server/Service/SessionService.cs
+++ b/Last-Stand-server/Server/Service/SessionService.cs
@@ -45,4 +45,18 @@ public class SessionService :  ISessionService
         var account = await _accountRepository.GetPlayerLoginDataByIdAsync(session.AccountId);
         return account?.PlayerId;
     }
+
+    public async Task<int?> GetAccountIdBySessionIdAsync(string sessionId)
+    {
+        var session = await _sessionRepository.GetValidSessionAsync(sessionId);
+        if (session == null)
+            return null;
+        
+        var account = await _accountRepository.GetPlayerLoginDataByIdAsync(session.AccountId);
+        if (account == null)
+            throw new Exception($"No player found with AccountId = {session.AccountId}");
+
+        
+        return account?.Id;
+    }
 }

--- a/Last-Stand-server/Server/Service/SessionService.cs
+++ b/Last-Stand-server/Server/Service/SessionService.cs
@@ -39,6 +39,10 @@ public class SessionService :  ISessionService
     public async Task<string?> GetPlayerIdBySessionIdAsync(string sessionId)
     {
         var session = await _sessionRepository.GetValidSessionAsync(sessionId);
-        return session?.AccountId.ToString();
+        if (session == null)
+            return null;
+        
+        var account = await _accountRepository.GetPlayerLoginDataByIdAsync(session.AccountId);
+        return account?.PlayerId;
     }
 }


### PR DESCRIPTION
## 📚작업 내용

- 플레이어 이름 추가 API, Session을 통한 인가 구현
- 플레이어 이름 조회 API, Session을 통한 인가 구현

## ◀️참고 사항

- Session-Id 헤더를 이용한 인증 방식 적용
- 세션이 없거나 유효하지 않을 경우 적절한 HTTP 상태 코드(401 Unauthorized) 및 메시지 반환
- 플레이어 이름 중복 체크, 신규 계정 여부 체크 로직 포함

## ✅체크리스트

- [x] 플레이어 이름 추가 API 정상 작동 확인
- [x] 플레이어 이름 조회 API 정상 작동 확인
 
